### PR TITLE
Code up some RAM!

### DIFF
--- a/spawn.yml
+++ b/spawn.yml
@@ -99,7 +99,7 @@
         timeout: 60
         name: "{{ vm_name }}{{ '%02d' | format(item) }}"
         memory: "{{ amount_of_memory | int }}"
-        balloon: "{{ minimum_memory | int | default(0) }}"
+        balloon: "{{ minimum_memory | default(0) | int }}"
         cores: "{{ number_of_vcpus | int }}"
         agent: true
         description: "{{ vm_description | default('A VM spawned by ProxMAAS and Ansible') }}"
@@ -118,6 +118,7 @@
           format: raw
           efitype: 4m
           pre_enrolled_keys: false
+        update: true
       loop: "{{ range(starting_number_target | int, vm_count | int + starting_number_target | int) | list }}"
       register: vm_result
 

--- a/spawn.yml
+++ b/spawn.yml
@@ -99,6 +99,7 @@
         timeout: 60
         name: "{{ vm_name }}{{ '%02d' | format(item) }}"
         memory: "{{ amount_of_memory | int }}"
+        balloon: "{{ minimum_memory | int | default(0) }}"
         cores: "{{ number_of_vcpus | int }}"
         agent: true
         description: "{{ vm_description | default('A VM spawned by ProxMAAS and Ansible') }}"

--- a/vars/production-ehi/dev-demo.yml
+++ b/vars/production-ehi/dev-demo.yml
@@ -3,6 +3,7 @@
 scsi_disk_layout:
   scsi0: "vm-storage:15,format=raw"
 amount_of_memory: "2048"
+minimum_memory: "1024"
 number_of_vcpus: "1"
 # You can define a list of IPs like thiS: (Nope, you can't.  You can only define a range of IPs at the moment!)
 # list_of_ips:

--- a/vars/production-ehi/dev-demo.yml
+++ b/vars/production-ehi/dev-demo.yml
@@ -17,5 +17,5 @@ ip_range:
 starting_number: "1"
 vm_name: dev-demo
 vm_description: "Development Demo node, used for showing off and testing out new things"
-# Testing variables for Technitium DNS
+# Variables for Technitium DNS, no record will be created if 'dns_record_type' is not defined
 dns_record_type: "A"

--- a/vars/production-ehi/prod-phos-k8s-w.yml
+++ b/vars/production-ehi/prod-phos-k8s-w.yml
@@ -3,6 +3,7 @@
 scsi_disk_layout:
   scsi0: "vm-storage:50,format=raw"
 amount_of_memory: 65536
+minimum_memory: 16384
 number_of_vcpus: 6
 ip_range:
   - start: 10.24.0.111


### PR DESCRIPTION
This is the tested PR to add RAM ballooning to our proxmaas setup, if approved I can dive in after and reclaim about ~2-3TB of RAM from the 'prod-phos-k8s-w' machines tomorrow. :muscle: 

Fixes: https://github.com/application-research/ehi-proxmaas/issues/11

Word of warning: This adds `update: true` to the proxmox_kvm module and will update many other aspects of a VM if they don't match our inventory files. (Which might cause unexpected behavior, but I imagine it will be fine.)